### PR TITLE
Change CMD to reflect src namespacei

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ RUN pip install --no-cache -r requirements-dev.txt
 
 COPY . .
 
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
Previously namespace referred to main.py, but restructuring lead to the need to move the main.py into the src folder.

fixes #6